### PR TITLE
add branch switching with stash support

### DIFF
--- a/src/bin/cargo_uv.rs
+++ b/src/bin/cargo_uv.rs
@@ -56,6 +56,7 @@ fn main() -> Result<()> {
     );
     drop(excluded);
 
+    // BUG: #40 Not using the the '--workspace-package' flag.
     let mut change_workspace_package_version = false;
     let mut tasks = Tasks::new();
 

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -1,15 +1,9 @@
-mod action;
-mod git_ops;
-mod manifest;
-mod suppress;
-mod workspace;
-
-pub use crate::cli::{
-    action::Action, git_ops::GitOps, manifest::Manifest, suppress::Suppress, workspace::Workspace,
-};
 use std::{ops::Deref, path::PathBuf};
 
-use crate::{GitBuilder, Result};
+use crate::{
+    Action, GitBuilder, Result,
+    cli::{CARGO_HEADER, GitOps, Manifest, Suppress, Workspace},
+};
 use cargo_metadata::Metadata;
 use miette::IntoDiagnostic;
 use semver::Version;
@@ -17,10 +11,6 @@ use tracing::{Level, debug, instrument};
 
 use crate::current_span;
 // use clap::ValueHint;
-
-static GIT_HEADER: &str = "Git";
-static CARGO_HEADER: &str = "Cargo";
-static WORKSPACE_HEADER: &str = "Package Selection";
 
 pub const CLAP_STYLING: clap::builder::styling::Styles = clap::builder::styling::Styles::styled()
     .header(clap_cargo::style::HEADER)

--- a/src/cli/git_ops.rs
+++ b/src/cli/git_ops.rs
@@ -1,3 +1,7 @@
+use std::{fmt::Display, str::FromStr};
+
+use clap::builder::OsStr;
+
 use crate::cli::GIT_HEADER;
 
 #[derive(Debug, clap::Args)]
@@ -24,4 +28,52 @@ pub struct GitOps {
     #[arg(long = "force-git", help = "Pass force into all git operations.",
         help_heading = GIT_HEADER)]
     pub force: bool,
+
+    /// Used to change branch for the execution of the program. Defaults to current branch.
+    #[arg(long, default_value = Branch::default(), hide_default_value(true), help_heading = GIT_HEADER)]
+    branch: Branch,
+}
+
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
+pub enum Branch {
+    #[default]
+    Current,
+    Other {
+        local: String,
+    },
+}
+
+impl Display for Branch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let text = match self {
+            Branch::Current => ".",
+            Branch::Other { local, .. } => &local,
+        };
+
+        write!(f, "{text}")
+    }
+}
+
+impl FromStr for Branch {
+    type Err = miette::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        if s.is_empty() || s == "." {
+            return Ok(Branch::Current);
+        }
+
+        Ok(Self::Other {
+            local: String::from(s),
+        })
+    }
+}
+
+impl From<Branch> for clap::builder::OsStr {
+    fn from(branch: Branch) -> Self {
+        match branch {
+            Branch::Current => OsStr::from("."),
+            Branch::Other { local } => OsStr::from(local),
+        }
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,17 @@
+mod action;
+mod cli;
+mod git_ops;
+mod manifest;
+mod suppress;
+mod workspace;
+
+pub use action::Action;
+pub use cli::Cli;
+pub use git_ops::{Branch, GitOps};
+pub use manifest::Manifest;
+pub use suppress::Suppress;
+pub use workspace::Workspace;
+
+static GIT_HEADER: &str = "Git";
+static CARGO_HEADER: &str = "Cargo";
+static WORKSPACE_HEADER: &str = "Package Selection";

--- a/src/git/git_file.rs
+++ b/src/git/git_file.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{path::PathBuf, str::FromStr, vec::IntoIter};
 
 use tracing::instrument;
 
@@ -94,5 +94,15 @@ impl GitFiles {
         } else {
             Some(GitFiles(ret))
         }
+    }
+}
+
+impl IntoIterator for GitFiles {
+    type Item = GitFile;
+
+    type IntoIter = IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -5,6 +5,5 @@ pub(crate) mod git_file;
 pub use git::Git;
 pub use git::GitBuilder;
 pub use git::NoRootDirSet;
-pub use git::OutputExt;
 pub use git_file::GitFile;
 pub use git_file::GitFiles;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,13 @@ pub(crate) mod error;
 pub(crate) mod git;
 pub(crate) mod manifest;
 pub(crate) mod packages;
+pub(crate) mod process;
 pub(crate) mod task;
 pub(crate) mod version;
 
 pub use cargo::Cargo;
-pub use cli::{Action, Cli};
-pub use git::{Git, GitBuilder, GitFile, GitFiles, NoRootDirSet, OutputExt};
+pub use cli::{Action, Branch, Cli};
+pub use git::{Git, GitBuilder, GitFile, GitFiles, NoRootDirSet};
 pub use manifest::error::{
     CargoFileError, CargoFileErrorKind, ItemType, VersionLocationErrorKind, VersionlocationError,
 };
@@ -20,6 +21,7 @@ pub use manifest::toml_file::{CargoFile, ReadToml, UnreadToml};
 pub use manifest::version_location::{VersionLocation, VersionType};
 pub use miette::Result;
 pub use packages::{Package, PackageError, PackageName, Packages};
+pub use process::OutputExt;
 pub use task::{Task, TaskError, Tasks};
 pub use version::{Bumpable, Setable};
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,19 @@
+use std::process::Output;
+
+#[allow(dead_code)]
+pub trait OutputExt {
+    fn stderr(&self) -> String;
+    fn stdout(&self) -> String;
+}
+
+impl OutputExt for Output {
+    fn stderr(&self) -> String {
+        String::from_iter(self.stderr.iter().map(|&c| char::from(c)))
+    }
+
+    fn stdout(&self) -> String {
+        String::from_iter(self.stdout.iter().map(|&c| char::from(c)))
+    }
+}
+
+// TODO: #41 Create an enum for spawn and output to run the process and display debug info pre running.

--- a/src/task.rs
+++ b/src/task.rs
@@ -109,6 +109,10 @@ pub enum Task {
         version: Version,
     },
     DeleteGitTag(Version),
+    ChangeBranch {
+        to: String,
+        from: String,
+    },
 }
 
 impl Display for Task {
@@ -125,6 +129,7 @@ impl Display for Task {
             Task::BumpWorkspace { bump, .. } => &format!("Bump Workspace Package: {}", bump),
             Task::SetWorkspace { version } => &format!("Set Workspace: {}", version.to_string()),
             Task::DeleteGitTag(version) => &format!("Delete Git Tag: {}", version.to_string()),
+            Task::ChangeBranch { to, .. } => &format!("Change branch: {}", to),
         };
         write!(f, "{}", text)
     }
@@ -133,9 +138,13 @@ impl Display for Task {
 impl Task {
     pub fn is_version_change(&self) -> bool {
         match self {
-            Task::Push(_) | Task::Publish | Task::Print | Task::DeleteGitTag(_) | Task::Tree => {
-                false
-            }
+            Task::ChangeBranch { .. }
+            | Task::Push(_)
+            | Task::Publish
+            | Task::Print
+            | Task::DeleteGitTag(_)
+            | Task::Tree => false,
+
             Task::Set { .. }
             | Task::Bump { .. }
             | Task::BumpWorkspace { .. }


### PR DESCRIPTION
Add a Branch enum to represent current or other branches and integrate it
into CLI options to allow specifying a branch for program execution.

Implement a checkout method that switches branches safely by stashing
uncommitted changes before checkout and optionally reverting the stash
afterwards. This prevents data loss during branch changes.

Add a branch method to run arbitrary `git branch` commands and extend
GitFiles with IntoIterator for easier iteration.

These changes improve branch management flexibility and robustness in
git operations.

Stash support is required to  be able to use --allow-dirty.