### PR TITLE
Use Process enum for tracing and error handling

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -1,7 +1,7 @@
 use std::{ops::Deref, path::PathBuf};
 
 use crate::{
-    Action, GitBuilder, Result,
+    Action, Branch, GitBuilder, Result,
     cli::{CARGO_HEADER, GitOps, Manifest, Suppress, Workspace},
 };
 use cargo_metadata::Metadata;
@@ -210,6 +210,14 @@ impl Cli {
 
     pub fn no_verify(&self) -> bool {
         self.no_verify
+    }
+
+    pub fn git_branch(&self) -> Branch {
+        self.git_ops.branch()
+    }
+
+    pub fn is_current_branch(&self) -> bool {
+        self.git_branch().is_current()
     }
 
     // /// Partition workspace members into those selected and those excluded.

--- a/src/cli/git_ops.rs
+++ b/src/cli/git_ops.rs
@@ -33,6 +33,11 @@ pub struct GitOps {
     #[arg(long, default_value = Branch::default(), hide_default_value(true), help_heading = GIT_HEADER)]
     branch: Branch,
 }
+impl GitOps {
+    pub fn branch(&self) -> Branch {
+        self.branch.clone()
+    }
+}
 
 #[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub enum Branch {
@@ -41,6 +46,40 @@ pub enum Branch {
     Other {
         local: String,
     },
+}
+
+impl Branch {
+    /// Returns `true` if the branch is [`Current`].
+    ///
+    /// [`Current`]: Branch::Current
+    #[must_use]
+    pub fn is_current(&self) -> bool {
+        matches!(self, Self::Current)
+    }
+
+    /// Returns `true` if the branch is [`Other`].
+    ///
+    /// [`Other`]: Branch::Other
+    #[must_use]
+    pub fn is_other(&self) -> bool {
+        matches!(self, Self::Other { .. })
+    }
+
+    pub fn as_other(&self) -> Option<&String> {
+        if let Self::Other { local } = self {
+            Some(local)
+        } else {
+            None
+        }
+    }
+
+    pub fn try_into_other(self) -> Result<String, Self> {
+        if let Self::Other { local } = self {
+            Ok(local)
+        } else {
+            Err(self)
+        }
+    }
 }
 
 impl Display for Branch {

--- a/src/git/git.rs
+++ b/src/git/git.rs
@@ -1,16 +1,20 @@
 use std::{
     fmt::Debug,
     path::{Path, PathBuf},
-    process::{Child, Command, Output, Stdio},
+    process::{Child, Command, Stdio},
     str::FromStr,
 };
 
-use miette::{Context, IntoDiagnostic, bail};
+use miette::{Context, bail};
 use semver::Version;
 use tracing::{debug, info, instrument, warn};
 
 use crate::{
-    Branch, Result, Task, cli::Cli, current_span, git::git_file::GitFiles, process::OutputExt,
+    Branch, Process, ProcessOutput, Result, Task,
+    cli::{Cli, Suppress},
+    current_span,
+    git::git_file::GitFiles,
+    process::OutputExt,
 };
 
 /// Used to indicate if the Root Dir is Set and can be used.
@@ -130,8 +134,7 @@ impl Git<PathBuf> {
 
         info!("Staging cargo files: {}, {}", cargo_toml, cargo_lock);
         git.args(["add", "-v", cargo_toml, cargo_lock, all_cargo_toml]);
-        tracing::debug!("Running: {:?}", git);
-        git.output().map(|_| ()).into_diagnostic()
+        Process::Output.run(git).map(|_| ())
     }
 }
 
@@ -139,10 +142,12 @@ impl Git<PathBuf> {
     /// Generates a list of dirty files.
     #[instrument(skip_all)]
     pub fn dirty_files(&self) -> miette::Result<GitFiles> {
-        let mut git_status = self.command(true);
-        git_status.args(["status", "--short"]);
-        tracing::debug!("Running: {:?}", git_status);
-        let stdout = git_status.output().into_diagnostic()?.stdout();
+        let mut git = self.command(true);
+        git.args(["status", "--short"]);
+        let stdout = match Process::Output.run(git)? {
+            ProcessOutput::Output(output) => output.stdout(),
+            _ => unreachable!(),
+        };
         if stdout.lines().count() == 0 {
             return Ok(GitFiles::new());
         };
@@ -170,8 +175,10 @@ impl Git<PathBuf> {
             }
         }
 
-        tracing::debug!("Running: {:?}", git);
-        let _stdout = git.output().into_diagnostic()?;
+        let _stdout = match Process::Output.run(git)? {
+            ProcessOutput::Output(output) => output.stdout(),
+            _ => unreachable!(),
+        };
         self.dirty_files().context("After Commit")?;
         Ok(())
     }
@@ -189,8 +196,10 @@ impl Git<PathBuf> {
             git.args(a);
         }
         git.args([&self.generate_tag(version)]);
-        tracing::debug!("Running: {:?}", git);
-        let output = git.output().into_diagnostic()?;
+        let output = match Process::Output.run(git)? {
+            ProcessOutput::Output(output) => output,
+            _ => unreachable!(),
+        };
         if !output.status.success() {
             tracing::debug!("stderr: {}", output.stderr());
             bail!("Failed to tag repository.")
@@ -222,9 +231,13 @@ impl Git<PathBuf> {
                     git_push.arg("--dry-run");
                 }
                 git_push.args([remote.as_str(), &tag_string, "--porcelain"]);
-                // let _ = dbg!(git_push.get_args());
                 tracing::debug!("Running: {:?}", git_push);
-                (task, git_push.spawn().into_diagnostic())
+                let child = match Process::Spawn.run(git_push) {
+                    Ok(ProcessOutput::Child(child)) => Ok(child),
+                    Err(e) => Err(e),
+                    _ => unreachable!(),
+                };
+                (task, child)
             })
             .collect::<Vec<_>>();
         let mut ret = vec![];
@@ -243,14 +256,13 @@ impl Git<PathBuf> {
     pub fn remotes(&self) -> miette::Result<Vec<String>> {
         let mut git = self.command(true);
         git.args(["remote"]);
-        tracing::debug!("Running: {:?}", git);
-        let remotes: Vec<String> = git
-            .output()
-            .into_diagnostic()?
-            .stdout()
-            .lines()
-            .map(String::from)
-            .collect();
+
+        let stdout = match Process::Output.run(git)? {
+            ProcessOutput::Output(output) => output.stdout(),
+            _ => unreachable!(),
+        };
+
+        let remotes: Vec<String> = stdout.lines().map(String::from).collect();
 
         let mut branch_remotes = Vec::new();
 
@@ -259,7 +271,10 @@ impl Git<PathBuf> {
                 Some((remote, _branch)) => remote.trim().to_string(),
                 None => {
                     warn!("Ensure you only run command on a branch with a remote.");
-                    bail!("Failed to find remote for current branch.")
+                    bail!(
+                        help = "Use the branch flag to change to valid branch",
+                        "Failed to find remote for current branch."
+                    )
                 }
             };
             assert!(remotes.contains(&valid_remote));
@@ -289,31 +304,42 @@ impl Git<PathBuf> {
         args.iter().for_each(|&arg| {
             git.arg(arg);
         });
-        tracing::debug!("Running: {:?}", git);
-        git.output().map(|output| output.stdout()).into_diagnostic()
+        let stdout = match Process::Output.run(git)? {
+            ProcessOutput::Output(output) => output.stdout(),
+            _ => unreachable!(),
+        };
+        Ok(stdout)
     }
 
     #[instrument(skip_all, fields(from, to, stash_revert_required))]
-    pub fn checkout(&self, cli_args: &Cli, branch: Branch) -> Result<(Branch, bool)> {
+    pub fn checkout(
+        &self,
+        cli_args: &Cli,
+        branch: Branch,
+        stash_state: Stash,
+    ) -> Result<(Branch, Stash)> {
         let span = current_span!();
         // Determine current branch to return.
-        let current_branch = match self
-            .command(false)
-            .args(["branch", "--show-current"])
-            .output()
-        {
-            Ok(b) => {
-                if b.status.success() {
-                    b.stdout()
-                } else {
-                    miette::bail!(
-                        help = "Failed to run 'git branch --show-current'",
-                        "{}",
-                        b.stderr()
-                    );
+        let mut cmd = self.command(false);
+        cmd.args(["branch", "--show-current"]);
+        cmd.stdout(Stdio::piped());
+
+        let current_branch = match Process::Output.run(cmd) {
+            Ok(output) => match output {
+                ProcessOutput::Output(b) => {
+                    if b.status.success() {
+                        b.stdout().trim_end().to_string()
+                    } else {
+                        miette::bail!(
+                            help = "Failed to run 'git branch --show-current'",
+                            "{}",
+                            b.stderr()
+                        );
+                    }
                 }
-            }
-            Err(e) => miette::bail!(help = "Failed to run 'git branch --show-current'", "{}", e),
+                _ => unreachable!(),
+            },
+            Err(e) => Err(e.wrap_err("Failed to run 'git branch --show-current'"))?,
         };
         span.record("from", &current_branch);
         span.record("to", branch.to_string());
@@ -321,18 +347,11 @@ impl Git<PathBuf> {
         let ret_branch = Branch::Other {
             local: current_branch,
         };
+        tracing::debug!("{:?}", ret_branch);
 
         // check if need to stash.
         // TODO: use `git stash {create, store, apply, drop}`
-        let files = self.dirty_files()?;
-        let mut revert_stash = false;
-        if !files.is_empty() {
-            let mut cmd = self.command(cli_args.suppress.includes_git());
-            cmd.args(["stash", "push"]);
-            tracing::debug!("Running: {:?}", cmd);
-            cmd.output().into_diagnostic()?;
-            revert_stash = true;
-        };
+        let revert_stash = self.stash(cli_args.suppress, stash_state)?;
 
         // Changing branch
         let mut cmd = self.command(cli_args.suppress.includes_git());
@@ -343,11 +362,13 @@ impl Git<PathBuf> {
             bail!("Can't change branch to current branch.")
         };
 
-        tracing::debug!("Running: {:?}", cmd);
-        let output = cmd
-            .output()
-            .into_diagnostic()
-            .context(format!("Failed to run: git checkout {}", &branch))?;
+        let output = match Process::Output
+            .run(cmd)
+            .context(format!("Failed to run: git checkout {}", &branch))?
+        {
+            ProcessOutput::Output(output) => output,
+            _ => unreachable!(),
+        };
 
         if !output.status.success() {
             miette::bail!(
@@ -358,5 +379,73 @@ impl Git<PathBuf> {
         }
 
         Ok((ret_branch, revert_stash))
+    }
+
+    pub fn stash(&self, suppress: Suppress, state: Stash) -> Result<Stash> {
+        // TODO: Ensure no dirty files after stash.
+        let files = self.dirty_files()?;
+        let mut ret_stash: Stash = state;
+
+        let mut git = self.command(suppress.includes_git());
+        git.arg("stash");
+
+        match state {
+            Stash::Stashed => {
+                git.arg("pop");
+                ret_stash = Stash::Unstashed
+            }
+            Stash::Unstashed => {
+                if !files.is_empty() {
+                    git.arg("push");
+                    ret_stash = Stash::Stashed
+                }
+            }
+            Stash::Dont => return Ok(state),
+        };
+        let command = Process::display_command(&git);
+        let run = Process::Output.run(git)?;
+
+        let output = run.as_output().unwrap();
+        if !output.status.success() {
+            miette::bail!(
+                help = format!("Failed to run '{}'", command),
+                "{}",
+                output.stderr()
+            );
+        };
+        Ok(ret_stash)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+pub enum Stash {
+    Stashed,
+    #[default]
+    Unstashed,
+    Dont,
+}
+
+impl Stash {
+    /// Returns `true` if the stash is [`Stashed`].
+    ///
+    /// [`Stashed`]: Stash::Stashed
+    #[must_use]
+    pub fn is_stashed(&self) -> bool {
+        matches!(self, Self::Stashed)
+    }
+
+    /// Returns `true` if the stash is [`Stashed`].
+    ///
+    /// [`Stashed`]: Stash::Stashed
+    pub fn revert_required(&self) -> bool {
+        self.is_stashed()
+    }
+
+    /// Returns `true` if the stash is [`Unstashed`].
+    ///
+    /// [`Unstashed`]: Stash::Unstashed
+    #[must_use]
+    pub fn is_unstashed(&self) -> bool {
+        matches!(self, Self::Unstashed)
     }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -5,5 +5,6 @@ pub(crate) mod git_file;
 pub use git::Git;
 pub use git::GitBuilder;
 pub use git::NoRootDirSet;
+pub use git::Stash;
 pub use git_file::GitFile;
 pub use git_file::GitFiles;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub(crate) mod version;
 
 pub use cargo::Cargo;
 pub use cli::{Action, Branch, Cli};
-pub use git::{Git, GitBuilder, GitFile, GitFiles, NoRootDirSet};
+pub use git::{Git, GitBuilder, GitFile, GitFiles, NoRootDirSet, Stash};
 pub use manifest::error::{
     CargoFileError, CargoFileErrorKind, ItemType, VersionLocationErrorKind, VersionlocationError,
 };
@@ -21,7 +21,7 @@ pub use manifest::toml_file::{CargoFile, ReadToml, UnreadToml};
 pub use manifest::version_location::{VersionLocation, VersionType};
 pub use miette::Result;
 pub use packages::{Package, PackageError, PackageName, Packages};
-pub use process::OutputExt;
+pub use process::{OutputExt, Process, ProcessOutput};
 pub use task::{Task, TaskError, Tasks};
 pub use version::{Bumpable, Setable};
 
@@ -29,6 +29,7 @@ use miette::{IntoDiagnostic, bail};
 use tracing::Level;
 use tracing_subscriber::util::SubscriberInitExt;
 
+/// Footer for the [miette::MietteHandler]
 pub static FOOTER: &str = "If the bug continues, raise an issue on github: https://github.com/Ozy-Viking/cargo_update_version/issues";
 
 pub fn setup_tracing(args: &Cli) -> miette::Result<()> {

--- a/src/task.rs
+++ b/src/task.rs
@@ -33,7 +33,7 @@ impl Tasks {
         self.keys().cloned().collect()
     }
 
-    /// [Vec<Task>] of incomplete tasks.
+    /// [`Vec<Task>`] of incomplete tasks.
     pub fn incomplete_tasks(&self) -> Vec<Task> {
         self.tasks
             .keys()
@@ -42,7 +42,7 @@ impl Tasks {
             .collect()
     }
 
-    /// [Vec<Task>] of completed [Task].
+    /// [`Vec<Task>`] of completed [Task].
     ///
     /// The underlying hashset can be accessed with [AsRef] and [AsMut]
     pub fn completed_tasks(&self) -> Vec<Task> {


### PR DESCRIPTION
- Replace direct Command output calls with Process trait abstractions for running and spawning git commands, enhancing consistency and error handling.
- Add contextual help to remote lookup errors to guide users on branch usage.
- Remove redundant debug logs and unused imports to clean up the codebase.